### PR TITLE
Add options for imageMagick to gm(buffer) calls.

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,20 +41,22 @@ module.exports = {
             reject(err);
           }
           else {
-            gm(buffer).size(function (e, size) {
-              if (err) {
-                reject(err);
-              }
-              else {
-                resolve({
-                  type: type,
-                  mimeType: 'image/' + type,
-                  contents: new Buffer(buffer),
-                  width: size && size.width ? size.width : opt.width,
-                  height: size && size.height ? size.height : opt.height
-                });
-              }
-            });
+            gm(buffer)
+              .options({imageMagick: useImagemagick(opt.options)})
+              .size(function (e, size) {
+                if (err) {
+                  reject(err);
+                }
+                else {
+                  resolve({
+                    type: type,
+                    mimeType: 'image/' + type,
+                    contents: new Buffer(buffer),
+                    width: size && size.width ? size.width : opt.width,
+                    height: size && size.height ? size.height : opt.height
+                  });
+                }
+              });
           }
         });
     });
@@ -70,20 +72,22 @@ module.exports = {
             reject(err);
           }
           else {
-            gm(buffer).size(function (e, size) {
-              if (err) {
-                reject(err);
-              }
-              else {
-                resolve({
-                  type: type.toLowerCase(),
-                  mimeType: 'image/' + type.toLowerCase(),
-                  contents: new Buffer(buffer),
-                  width: size && size.width ? size.width : opt.width,
-                  height: size && size.height ? size.height : opt.height
-                });
-              }
-            });
+            gm(buffer)
+              .options({imageMagick: useImagemagick(opt.options)})
+              .size(function (e, size) {
+                if (err) {
+                  reject(err);
+                }
+                else {
+                  resolve({
+                    type: type.toLowerCase(),
+                    mimeType: 'image/' + type.toLowerCase(),
+                    contents: new Buffer(buffer),
+                    width: size && size.width ? size.width : opt.width,
+                    height: size && size.height ? size.height : opt.height
+                  });
+                }
+              });
           }
         });
     });


### PR DESCRIPTION
Right now the imageMagick option doesn't get passed when gm is ran through a buffer. You end up with a false positive when you add `"gm-use-imagemagick": true` and have both imageMagick and graphics/magick installed. graphicsMagick ends up being used when a buffer is being processed even when you are telling it to use imageMagick.
